### PR TITLE
Adds weekly and monthly stars to repo object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
             .replace(',', '') || '0', 0),
           forks: parseInt($(repo).find(`[href="${forkLink}"]`).text().trim()
             .replace(',', '') || '0', 0),
-          starsInPeriod: parseInt('0')
+          starsInPeriod: parseInt('0', 0)
         }
 
         switch (period as string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ type Repository = {
   language: string,
   stars: number,
   forks: number,
-  starsInPeriod: number,
+  starsInPeriod: number | null,
 };
 
 const trendingGitHub = (period: string = 'daily', language: string = '') => (
@@ -35,7 +35,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
             .replace(',', '') || '0', 0),
           forks: parseInt($(repo).find(`[href="${forkLink}"]`).text().trim()
             .replace(',', '') || '0', 0),
-          starsInPeriod: parseInt('0', 0)
+          starsInPeriod: null,
         }
 
         switch (period as string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ type Repository = {
   language: string,
   stars: number,
   forks: number,
-  starsToday: number,
+  starsToday?: number,
+  starsThisWeek?: number,
+  starsThisMonth?: number,
 };
 
 const trendingGitHub = (period: string = 'daily', language: string = '') => (
@@ -25,7 +27,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
         const starLink = `/${title.replace(/ /g, '')}/stargazers`;
         const forkLink = `/${title.replace(/ /g, '')}/network`;
 
-        const indexRepo = {
+        const indexRepo: Repository = {
           author: title.split(' / ')[0],
           name: title.split(' / ')[1],
           href: `https://github.com/${title.replace(/ /g, '')}`,
@@ -37,7 +39,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
             .replace(',', '') || '0', 0),
         }
 
-        switch (period) {
+        switch (period as string) {
           case 'daily':
             indexRepo.starsToday = parseInt(
               $(repo)

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
         const starLink = `/${title.replace(/ /g, '')}/stargazers`;
         const forkLink = `/${title.replace(/ /g, '')}/network`;
 
-        repos.push({
+        const indexRepo = {
           author: title.split(' / ')[0],
           name: title.split(' / ')[1],
           href: `https://github.com/${title.replace(/ /g, '')}`,
@@ -35,10 +35,47 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
             .replace(',', '') || '0', 0),
           forks: parseInt($(repo).find(`[href="${forkLink}"]`).text().trim()
             .replace(',', '') || '0', 0),
-          starsToday: parseInt($(repo).find('span.float-sm-right:contains("stars today")').text().trim()
-            .replace('stars today', '')
-            .replace(',', '') || '0', 0),
-        });
+        }
+
+        switch (period) {
+          case 'daily':
+            indexRepo.starsToday = parseInt(
+              $(repo)
+                .find('span.float-sm-right:contains("stars today")')
+                .text()
+                .trim()
+                .replace('stars today', '')
+                .replace(',', '') || '0',
+              0,
+            )
+            break
+          case 'weekly':
+            indexRepo.starsThisWeek = parseInt(
+              $(repo)
+                .find('span.float-sm-right:contains("stars this week")')
+                .text()
+                .trim()
+                .replace('stars this week', '')
+                .replace(',', '') || '0',
+              0,
+            )
+            break
+          case 'monthly':
+            indexRepo.starsThisMonth = parseInt(
+              $(repo)
+                .find('span.float-sm-right:contains("stars this month")')
+                .text()
+                .trim()
+                .replace('stars this month', '')
+                .replace(',', '') || '0',
+              0,
+            )
+            break
+          default:
+            break
+        }
+
+        repos.push(indexRepo);
       });
 
       resolve(repos);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,7 @@ type Repository = {
   language: string,
   stars: number,
   forks: number,
-  starsToday?: number,
-  starsThisWeek?: number,
-  starsThisMonth?: number,
+  starsInPeriod: number,
 };
 
 const trendingGitHub = (period: string = 'daily', language: string = '') => (
@@ -37,11 +35,12 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
             .replace(',', '') || '0', 0),
           forks: parseInt($(repo).find(`[href="${forkLink}"]`).text().trim()
             .replace(',', '') || '0', 0),
+          starsInPeriod: parseInt('0')
         }
 
         switch (period as string) {
           case 'daily':
-            indexRepo.starsToday = parseInt(
+            indexRepo.starsInPeriod = parseInt(
               $(repo)
                 .find('span.float-sm-right:contains("stars today")')
                 .text()
@@ -52,7 +51,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
             )
             break
           case 'weekly':
-            indexRepo.starsThisWeek = parseInt(
+            indexRepo.starsInPeriod = parseInt(
               $(repo)
                 .find('span.float-sm-right:contains("stars this week")')
                 .text()
@@ -63,7 +62,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
             )
             break
           case 'monthly':
-            indexRepo.starsThisMonth = parseInt(
+            indexRepo.starsInPeriod = parseInt(
               $(repo)
                 .find('span.float-sm-right:contains("stars this month")')
                 .text()


### PR DESCRIPTION
This change checks whether the selected period is "daily", "weekly" or "monthly" and includes the number of stars in the repository object.

Previously only "daily" was being handled.