### PR TITLE
Add type parameter for better type declaration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ type Repository = {
 };
 
 const trendingGitHub = (period: string = 'daily', language: string = '') => (
-  new Promise((resolve, reject) => axios
+  new Promise<Repository[]>((resolve, reject) => axios
     .get(`https://github.com/trending/${encodeURIComponent(language)}?since=${period}`, {
       headers: {
         Accept: 'text/html',


### PR DESCRIPTION
This change makes a better type declaration.

Currently, default exported function (trendingGithub) returns `Promise<unknown>`.

But actually, trendingGithub returns `Promise<Repository[]>`.

So, I added type parameter for better type declaration.