### PR TITLE
fix: forks value return zero

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const trendingGitHub = (period: string = 'daily', language: string = '') => (
         const name = title.split('/')[1];
 
         const starLink = `/${title.replace(/ /g, '')}/stargazers`;
-        const forkLink = `/${title.replace(/ /g, '')}/network/members.${name}`;
+        const forkLink = `/${title.replace(/ /g, '')}/network/members`;
 
         let text = '';
         if (period === 'daily') {


### PR DESCRIPTION
Previously the query looking for url `/network/members.{reponame}`

<img width="400" alt="image" src="https://user-images.githubusercontent.com/4416419/219940424-5b5633f0-4834-42b3-954e-89161fee3963.png">

unfortunately, the path has change and it will return 0.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/4416419/219940397-d0f0e4be-2869-47a2-bc3e-f378a8387866.png">
